### PR TITLE
Update semantic search result parsing to match latest API changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "semantic-search-demo",
-	"version": "0.3.0",
+	"version": "0.3.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "semantic-search-demo",
-			"version": "0.3.0",
+			"version": "0.3.8",
 			"dependencies": {
 				"@picocss/pico": "^2.0.6",
 				"posthog-js": "^1.139.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "semantic-search-demo",
-	"version": "0.3.0",
+	"version": "0.3.8",
 	"private": true,
 	"scripts": {
 		"dev": "vite dev",

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,6 +1,6 @@
 <footer class="fluid-container">
 	<hr />
-	<p>GeoDiscovery, Canada Centre for Mapping and Earth Observation, Government of Canada, 2024</p>
+	<p>GeoDiscovery, Canada Centre for Mapping and Earth Observation, Government of Canada, 2024–2025</p>
 </footer>
 
 <style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -62,7 +62,7 @@
 <main class="fluid-container">
 	<section class="container" id="title">
 		<h1>Semantic Search API Demo for GEO.ca</h1>
-		<p>Front-end demo v{version} (2024-07-04), work-in-progress</p>
+		<p>Front-end demo v{version} (2025-01-23), work-in-progress</p>
 	</section>
 
 	<section class="container grid">
@@ -119,21 +119,21 @@
 					{#await semanticPromise}
 						{@render loadingResults()}
 					{:then data}
-						{#if data.body && data.body.response && data.body.response.total_hits > 0}
-							<!-- <p>
-									1 – {data.body.response.total_hits} of {data.body.response.total_hits}(?) records
-								</p> -->
+						{#if data.response && data.response.total_hits > 0}
+							<p class="center">1 – {data.response.returned_hits} of {data.response.total_hits} records</p>
 							<div class="search-results">
-								{#each data.body.response.items as item (item.features[0].properties.row_num)}
+								{#each data.response.items as item (item.features[0].properties.row_num)}
 									{@const record = item.features[0].properties}
 									<RecordCard {record} />
 								{/each}
 							</div>
-						{:else if data.body && data.body.response && data.body.response.total_hits === 0}
+						{:else if data.response && data.response.total_hits === 0}
 							<p>No result</p>
 						{:else}
+							<p class="error">Parse error.  This demo likely needs to be updated to the latest API.</p>
+							<p>Returned results in JSON format:</p>
 							<p class="error">{data.message}</p>
-							<textarea rows="20" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
+							<textarea rows="50" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
 						{/if}
 					{:catch error}
 						<p class="error">Error: {error}</p>
@@ -148,7 +148,7 @@
 						{@render loadingResults()}
 					{:then data}
 						{#if data.Count > 0}
-							<!-- <p>1 – {data.Count} of {data.Items[0].total} records</p> -->
+							<p class="center">1 – {data.Count} of {data.Items[0].total} records</p>
 							<div class="search-results">
 								{#each data.Items as record (record.row_num)}
 									<RecordCard {record} />
@@ -190,6 +190,9 @@
 	}
 	p.error {
 		color: red;
+	}
+	p.center {
+		text-align: center;
 	}
 	textarea {
 		field-sizing: content;


### PR DESCRIPTION
Previously, the semantic search results were enclosed inside "body", but they have been moved up a level for simplicity and consistency with keyword search, so the front end parsing needs to be adjusted accordingly, namely:

    data.body.response → data.response

Thanks to Joost van Ulden, Bo Lu and Xinli Cai for letting me know!

Also, now that both returned_hits and total_hits are available, we can show e.g. "1 – 10 of 320 records" now.

Bump version to v0.3.8 for good fortune.
Happy Lunar New Year, coming soon!

Fixes #6