### PR TITLE
Extending search comparison to multiple systems and multiple languages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
 	"name": "semantic-search-demo",
-	"version": "0.3.8",
+	"version": "0.3.10",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "semantic-search-demo",
-			"version": "0.3.8",
+			"version": "0.3.10",
 			"dependencies": {
+				"@inlang/paraglide-js": "^2.20.2",
 				"@picocss/pico": "^2.0.6",
-				"posthog-js": "^1.139.5"
+				"posthog-js": "^1.398.2"
 			},
 			"devDependencies": {
 				"@eslint/compat": "^1.2.5",
@@ -706,11 +707,61 @@
 				"url": "https://github.com/sponsors/nzakas"
 			}
 		},
+		"node_modules/@inlang/paraglide-js": {
+			"version": "2.20.2",
+			"resolved": "https://registry.npmjs.org/@inlang/paraglide-js/-/paraglide-js-2.20.2.tgz",
+			"integrity": "sha512-V8iY3uu/vQU94gEag1bdC3glMJSp4Dg3XMwfnabZLBh1Dv0F++DvDYlMeniqv2+nHbnS/twB75AM140OmpHDEg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inlang/recommend-sherlock": "^0.2.1",
+				"@inlang/sdk": "^2.10.0",
+				"commander": "11.1.0",
+				"consola": "3.4.0",
+				"json5": "2.2.3",
+				"unplugin": "^2.1.2",
+				"urlpattern-polyfill": "^10.0.0"
+			},
+			"bin": {
+				"paraglide-js": "bin/run.js"
+			},
+			"peerDependencies": {
+				"typescript": ">=5.6"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inlang/recommend-sherlock": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@inlang/recommend-sherlock/-/recommend-sherlock-0.2.1.tgz",
+			"integrity": "sha512-ckv8HvHy/iTqaVAEKrr+gnl+p3XFNwe5D2+6w6wJk2ORV2XkcRkKOJ/XsTUJbPSiyi4PI+p+T3bqbmNx/rDUlg==",
+			"license": "MIT",
+			"dependencies": {
+				"comment-json": "^4.2.3"
+			}
+		},
+		"node_modules/@inlang/sdk": {
+			"version": "2.10.2",
+			"resolved": "https://registry.npmjs.org/@inlang/sdk/-/sdk-2.10.2.tgz",
+			"integrity": "sha512-O1ki72SNK6LPagaGrvlioBb1mWKvump7cO7P85hfGZjdFTmDdn3icI0A6MvaBsB3P9KQHAjzyubnN1OslGufTw==",
+			"license": "MIT",
+			"dependencies": {
+				"@lix-js/sdk": "0.4.10",
+				"@sinclair/typebox": "^0.31.17",
+				"kysely": "^0.28.12",
+				"sqlite-wasm-kysely": "0.3.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.8",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
 			"integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/set-array": "^1.2.1",
@@ -721,11 +772,20 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -735,7 +795,6 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
 			"integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -745,19 +804,41 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
 			"integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.25",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
 			"integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
 			}
+		},
+		"node_modules/@lix-js/sdk": {
+			"version": "0.4.10",
+			"resolved": "https://registry.npmjs.org/@lix-js/sdk/-/sdk-0.4.10.tgz",
+			"integrity": "sha512-0dMInAJK/67guTG5rRZaCEhvzC5cCXENOjaePA5AqMXrCE97kaY7SRor9e2vnoGsFIiGqXKlT0MCIoZj36G0gg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@lix-js/server-protocol-schema": "0.1.1",
+				"dedent": "1.5.1",
+				"human-id": "^4.1.1",
+				"js-sha256": "^0.11.0",
+				"kysely": "^0.28.12",
+				"sqlite-wasm-kysely": "0.3.0",
+				"uuid": "^14.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@lix-js/server-protocol-schema": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@lix-js/server-protocol-schema/-/server-protocol-schema-0.1.1.tgz",
+			"integrity": "sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -827,6 +908,21 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
 			"integrity": "sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@posthog/core": {
+			"version": "1.39.6",
+			"resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.39.6.tgz",
+			"integrity": "sha512-o6ajIwN5zXoNP0D4H/QPmOyibNTUkSyOR6ya7AG5U2ywXx4awo72L2KnCoiZPQM5x/bXv6jPBdimH8M18Ax0aw==",
+			"license": "MIT",
+			"dependencies": {
+				"@posthog/types": "^1.392.0"
+			}
+		},
+		"node_modules/@posthog/types": {
+			"version": "1.392.1",
+			"resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.392.1.tgz",
+			"integrity": "sha512-Qg6Gl7/1vlr8+gPtBi5gwnLgAgiyFoKOVmTvTtDcvya9cpTwZfna7rQmkGQ4B63CunUYNNbOlqcwiUwUDyTK6w==",
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1095,14 +1191,19 @@
 				"win32"
 			]
 		},
-		"node_modules/@rrweb/types": {
-			"version": "2.0.0-alpha.17",
-			"resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.17.tgz",
-			"integrity": "sha512-AfDTVUuCyCaIG0lTSqYtrZqJX39ZEYzs4fYKnexhQ+id+kbZIpIJtaut5cto6dWZbB3SEe4fW0o90Po3LvTmfg==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"rrweb-snapshot": "^2.0.0-alpha.17"
+		"node_modules/@sinclair/typebox": {
+			"version": "0.31.28",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.28.tgz",
+			"integrity": "sha512-/s55Jujywdw/Jpan+vsy6JZs1z2ZTGxTmbZTPiuSL2wz9mfzA2gN1zzaqmvfi4pq+uOt7Du85fkiwv5ymW84aQ==",
+			"license": "MIT"
+		},
+		"node_modules/@sqlite.org/sqlite-wasm": {
+			"version": "3.48.0-build4",
+			"resolved": "https://registry.npmjs.org/@sqlite.org/sqlite-wasm/-/sqlite-wasm-3.48.0-build4.tgz",
+			"integrity": "sha512-hI6twvUkzOmyGZhQMza1gpfqErZxXRw6JEsiVjUbo7tFanVD+8Oil0Ih3l2nGzHdxPI41zFmfUQG7GHqhciKZQ==",
+			"license": "Apache-2.0",
+			"bin": {
+				"sqlite-wasm": "bin/index.js"
 			}
 		},
 		"node_modules/@sveltejs/adapter-auto": {
@@ -1485,6 +1586,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/trusted-types": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+			"integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+			"license": "MIT",
+			"optional": true
+		},
 		"node_modules/@types/unist": {
 			"version": "2.0.11",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
@@ -1812,10 +1920,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-			"dev": true,
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -1893,6 +2000,12 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/array-timsort": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
+			"integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
+			"license": "MIT"
 		},
 		"node_modules/assertion-error": {
 			"version": "2.0.1",
@@ -2147,12 +2260,43 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/commander": {
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+			"integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/comment-json": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/comment-json/-/comment-json-4.6.2.tgz",
+			"integrity": "sha512-R2rze/hDX30uul4NZoIZ76ImSJLFxn/1/ZxtKC1L77y2X1k+yYu1joKbAtMA2Fg3hZrTOiw0I5mwVMo0cf250w==",
+			"license": "MIT",
+			"dependencies": {
+				"array-timsort": "^1.0.3",
+				"esprima": "^4.0.1"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/consola": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.0.tgz",
+			"integrity": "sha512-EiPU8G6dQG0GFHNR8ljnZFki/8a+cQwEQ+7wpxdChl02Q8HXlwEZWD5lqAF8vC2sEC3Tehr8hy7vErz88LHyUA==",
+			"license": "MIT",
+			"engines": {
+				"node": "^14.18.0 || >=16.10.0"
+			}
 		},
 		"node_modules/cookie": {
 			"version": "0.6.0",
@@ -2165,9 +2309,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.40.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
-			"integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+			"integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -2221,6 +2365,20 @@
 				}
 			}
 		},
+		"node_modules/dedent": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.1.tgz",
+			"integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
+			"license": "MIT",
+			"peerDependencies": {
+				"babel-plugin-macros": "^3.1.0"
+			},
+			"peerDependenciesMeta": {
+				"babel-plugin-macros": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/deep-eql": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -2267,6 +2425,15 @@
 			"integrity": "sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/dompurify": {
+			"version": "3.4.11",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+			"integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+			"license": "(MPL-2.0 OR Apache-2.0)",
+			"optionalDependencies": {
+				"@types/trusted-types": "^2.0.7"
+			}
 		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.104",
@@ -2551,6 +2718,19 @@
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/esprima": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"license": "BSD-2-Clause",
+			"bin": {
+				"esparse": "bin/esparse.js",
+				"esvalidate": "bin/esvalidate.js"
+			},
+			"engines": {
+				"node": ">=4"
 			}
 		},
 		"node_modules/esquery": {
@@ -2854,6 +3034,15 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/human-id": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/human-id/-/human-id-4.2.0.tgz",
+			"integrity": "sha512-K3GbkIWqyvvlpfhBPlbEvD97TtqBpAYA4kt+cn2lD2x2HuohzZCibcA2nOlnJT6exqvJLggoB5nv2dNf192nEA==",
+			"license": "MIT",
+			"bin": {
+				"human-id": "dist/cli.js"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2962,6 +3151,12 @@
 				"jiti": "lib/jiti-cli.mjs"
 			}
 		},
+		"node_modules/js-sha256": {
+			"version": "0.11.1",
+			"resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+			"integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+			"license": "MIT"
+		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -2996,6 +3191,18 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json5": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"license": "MIT",
+			"bin": {
+				"json5": "lib/cli.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
 			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3022,6 +3229,15 @@
 			"integrity": "sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/kysely": {
+			"version": "0.28.17",
+			"resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.17.tgz",
+			"integrity": "sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.0.0"
+			}
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
@@ -3444,6 +3660,7 @@
 			"version": "3.3.8",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
 			"integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -3586,16 +3803,14 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
 			"integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-			"integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-			"dev": true,
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -3639,6 +3854,7 @@
 			"version": "8.5.3",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
 			"integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3769,24 +3985,25 @@
 			"license": "MIT"
 		},
 		"node_modules/posthog-js": {
-			"version": "1.223.3",
-			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.223.3.tgz",
-			"integrity": "sha512-ZQTc17M21IzkQmECJa2Xjont4tZrvIn252uGT3sTfmahTqZoW4j+kBj4eOJt9SNR6hOheFNkg7MSiI/rA6FaDA==",
-			"license": "MIT",
+			"version": "1.398.2",
+			"resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.398.2.tgz",
+			"integrity": "sha512-BnxjHtEGOjcSBJ4nGqdfsy30ES3hEMKwXzjTnxKl2XEiGdF41sAFCGaUWRK/EpWTKjpJSWUY7tZs6dM51Zjl2w==",
+			"license": "(Apache-2.0 AND MIT)",
 			"dependencies": {
-				"core-js": "^3.38.1",
+				"@posthog/core": "^1.39.6",
+				"@posthog/types": "^1.392.1",
+				"core-js": "^3.49.0",
+				"dompurify": "^3.3.2",
 				"fflate": "^0.4.8",
-				"preact": "^10.19.3",
-				"web-vitals": "^4.2.0"
-			},
-			"peerDependencies": {
-				"@rrweb/types": "2.0.0-alpha.17"
+				"preact": "^10.29.3",
+				"query-selector-shadow-dom": "^1.0.1",
+				"web-vitals": "^5.3.0"
 			}
 		},
 		"node_modules/preact": {
-			"version": "10.26.2",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.26.2.tgz",
-			"integrity": "sha512-0gNmv4qpS9HaN3+40CLBAnKe0ZfyE4ZWo5xKlC1rVrr0ckkEvJvAQqKaHANdFKsGstoxrY4AItZ7kZSGVoVjgg==",
+			"version": "10.29.5",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.29.5.tgz",
+			"integrity": "sha512-zIai7HLEIz9c4GNfqpiuu5K9I1szXNtx0Ykr8f1Vbm1NasSVIvXGRxc8R8alLC+G+zonAt0TiUUBMn4+CiTgaA==",
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -3936,6 +4153,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/query-selector-shadow-dom": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+			"integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+			"license": "MIT"
+		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4029,16 +4252,6 @@
 				"@rollup/rollup-win32-ia32-msvc": "4.34.8",
 				"@rollup/rollup-win32-x64-msvc": "4.34.8",
 				"fsevents": "~2.3.2"
-			}
-		},
-		"node_modules/rrweb-snapshot": {
-			"version": "2.0.0-alpha.18",
-			"resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
-			"integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"postcss": "^8.4.38"
 			}
 		},
 		"node_modules/run-parallel": {
@@ -4147,9 +4360,21 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
 			"integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sqlite-wasm-kysely": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/sqlite-wasm-kysely/-/sqlite-wasm-kysely-0.3.0.tgz",
+			"integrity": "sha512-TzjBNv7KwRw6E3pdKdlRyZiTmUIE0UttT/Sl56MVwVARl/u5gp978KepazCJZewFUnlWHz9i3NQd4kOtP/Afdg==",
+			"dependencies": {
+				"@sqlite.org/sqlite-wasm": "^3.48.0-build2"
+			},
+			"peerDependencies": {
+				"kysely": "*"
 			}
 		},
 		"node_modules/stackback": {
@@ -4439,7 +4664,7 @@
 			"version": "5.7.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
 			"integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"tsc": "bin/tsc",
@@ -4486,6 +4711,21 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/unplugin": {
+			"version": "2.3.11",
+			"resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
+			"integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/remapping": "^2.3.5",
+				"acorn": "^8.15.0",
+				"picomatch": "^4.0.3",
+				"webpack-virtual-modules": "^0.6.2"
+			},
+			"engines": {
+				"node": ">=18.12.0"
+			}
+		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
@@ -4527,12 +4767,31 @@
 				"punycode": "^2.1.0"
 			}
 		},
+		"node_modules/urlpattern-polyfill": {
+			"version": "10.1.0",
+			"resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.1.0.tgz",
+			"integrity": "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw==",
+			"license": "MIT"
+		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/uuid": {
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist-node/bin/uuid"
+			}
 		},
 		"node_modules/vfile-message": {
 			"version": "2.0.4",
@@ -4749,10 +5008,16 @@
 			}
 		},
 		"node_modules/web-vitals": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
-			"integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+			"integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==",
 			"license": "Apache-2.0"
+		},
+		"node_modules/webpack-virtual-modules": {
+			"version": "0.6.2",
+			"resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+			"integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+			"license": "MIT"
 		},
 		"node_modules/which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
 		"lint": "prettier --check . && eslint .",
+		"paraglide": "paraglide-js compile",
 		"format": "prettier --write .",
 		"test:integration": "playwright test",
 		"test:unit": "vitest"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@inlang/paraglide-js": "^2.20.2",
 		"@picocss/pico": "^2.0.6",
-		"posthog-js": "^1.139.5"
+		"posthog-js": "^1.398.2"
 	}
 }

--- a/project.inlang/message-format.config.js
+++ b/project.inlang/message-format.config.js
@@ -1,3 +1,0 @@
-export default {
-    pathPattern: "./src/i18n/{locale}.json"
-};

--- a/project.inlang/message-format.config.js
+++ b/project.inlang/message-format.config.js
@@ -1,0 +1,3 @@
+export default {
+    pathPattern: "./src/i18n/{locale}.json"
+};

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -1,0 +1,12 @@
+
+{
+  "$schema": "https://inlang.com/schema/project-settings",
+  "baseLocale": "en",
+  "locales": [
+    "en",
+    "fr"
+  ],
+  "modules": [
+    "https://cdn.jsdelivr.net/npm/@inlang/message-format-plugin/dist/index.js"
+  ]
+}

--- a/project.inlang/settings.json
+++ b/project.inlang/settings.json
@@ -7,6 +7,9 @@
     "fr"
   ],
   "modules": [
-    "https://cdn.jsdelivr.net/npm/@inlang/message-format-plugin/dist/index.js"
-  ]
+    "https://cdn.jsdelivr.net/npm/@inlang/plugin-message-format@latest/dist/index.js"
+  ],
+  "plugin.inlang.messageFormat": {
+    "pathPattern": "./src/i18n/{locale}.json"
+    }
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,3 +1,11 @@
 {
-    "website_title": "Semantic Search API Demo for GEO.ca"
+    "website_header": "Semantic Search API Demo for GEO.ca",
+    "semantic_search_description": "Semantic search engines surpass simple keyword matching by interpreting the intent and context of queries. Unlike traditional searches, semantic search processes natural language and complex requests, recognizing synonyms and variations. We fine-tuned Sentence-Transformer models to enhance search relevance for geospatial metadata. The semantic search API is deployed using Amazon OpenSearch and Amazon SageMaker.",
+    "visit_github_call": "Visit our GitHub repositories:",
+    "keyword_search": "Keyword Search",
+    "semantic_search": "Semantic Search",
+    "semantic_search_new": "Semantic Search *New*",
+    "search_button": "Search",
+    "parse_error": "Parse error. This demo likely needs to be updated to the latest API.",
+    "search_load_message": "Fetching search results…"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,3 @@
+{
+    "website_title": "Semantic Search API Demo for GEO.ca",
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,4 +1,5 @@
 {
+    "header_text": "Canadian Geospatial Platform",
     "website_header": "Semantic Search API Demo for GEO.ca",
     "semantic_search_description": "Semantic search engines surpass simple keyword matching by interpreting the intent and context of queries. Unlike traditional searches, semantic search processes natural language and complex requests, recognizing synonyms and variations. We fine-tuned Sentence-Transformer models to enhance search relevance for geospatial metadata. The semantic search API is deployed using Amazon OpenSearch and Amazon SageMaker.",
     "visit_github_call": "Visit our GitHub repositories:",
@@ -6,6 +7,23 @@
     "semantic_search": "Semantic Search",
     "semantic_search_new": "Semantic Search *New*",
     "search_button": "Search",
+    "error_label": "Error:",
     "parse_error": "Parse error. This demo likely needs to be updated to the latest API.",
-    "search_load_message": "Fetching search results…"
+    "parse_error_json_output": "Returned results in JSON format:",
+    "search_load_message": "Fetching search results…",
+    "results_text": "results",
+    "records_retrieved_text": "1 - {data_count} of {total} records",
+
+    "record_card": {
+        "keywords": "Keywords:",
+        "organization": "Organization:",
+        "published": "Published:",
+        "Relevancy": "Relevancy:",
+        "Popularity": "Popularity:",
+        "view_record": "View record"
+    },
+
+    "footer_text": "GeoDiscovery, Canada Centre for Mapping and Earth Observation, Government of Canada, 2024–2025"
+
+
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -14,14 +14,12 @@
     "results_text": "results",
     "records_retrieved_text": "1 - {data_count} of {total} records",
 
-    "record_card": {
-        "keywords": "Keywords:",
-        "organization": "Organization:",
-        "published": "Published:",
-        "Relevancy": "Relevancy:",
-        "Popularity": "Popularity:",
-        "view_record": "View record"
-    },
+    "record_card_keywords": "Keywords:",
+    "record_card_organization": "Organization:",
+    "record_card_published": "Published:",
+    "record_card_relevancy": "Relevancy:",
+    "record_card_popularity": "Popularity:",
+    "record_card_view_record": "View record",
 
     "footer_text": "GeoDiscovery, Canada Centre for Mapping and Earth Observation, Government of Canada, 2024–2025"
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,3 +1,3 @@
 {
-    "website_title": "Semantic Search API Demo for GEO.ca",
+    "website_title": "Semantic Search API Demo for GEO.ca"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,4 +1,5 @@
 {
+    "header_text": "Plateforme Géospatiale Canadienne",
     "website_header": "Démonstration de l’API de recherche sémantique pour GEO.ca",
     "semantic_search_description": "Les moteurs de recherche sémantiques surpassent la simple correspondance de mots-clés en interprétant l’intention et le contexte des requêtes. Contrairement aux recherches traditionnelles, la recherche sémantique traite le langage naturel et les requêtes complexes, en reconnaissant les synonymes et les variations. Nous avons affiné les modèles de transformateurs de phrases pour améliorer la pertinence de la recherche de métadonnées géospatiales. L’API de recherche sémantique est déployée à l’aide d’Amazon OpenSearch et d’Amazon SageMaker.",
     "visit_github_call": "Visitez nos dépôts GitHub:",
@@ -6,7 +7,21 @@
     "semantic_search": "Recherche Sémantique",
     "semantic_search_new": "Recherche Sémantique *Nouveau*",
     "search_button": "Rechercher",
+    "error_label": "Erreur:",
     "parse_error": "Erreur d’analyse. Cette démonstration doit probablement être mise à jour vers la dernière API.",
-    "search_load_message": "Récupération des résultats de recherche…"
+    "parse_error_json_output": "Résultats renvoyés au format JSON:",
+    "search_load_message": "Récupération des résultats de recherche…",
+    "results_text": "résultats",
+    "records_retrieved_text": "1 - {data_count} de {total} dossiers",
 
+    "record_card": {
+        "keywords": "Mots-clés:",
+        "organization": "Organisation:",
+        "published": "Publié:",
+        "Relevancy": "Pertinence:",
+        "Popularity": "Popularité:",
+        "view_record": "Voir le dossier"
+    },
+
+    "footer_text": "GéoDécouverte, Centre canadien de cartographie et d’observation de la Terre, gouvernement du Canada, 2024–2025"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -13,15 +13,13 @@
     "search_load_message": "Récupération des résultats de recherche…",
     "results_text": "résultats",
     "records_retrieved_text": "1 - {data_count} de {total} dossiers",
-
-    "record_card": {
-        "keywords": "Mots-clés:",
-        "organization": "Organisation:",
-        "published": "Publié:",
-        "Relevancy": "Pertinence:",
-        "Popularity": "Popularité:",
-        "view_record": "Voir le dossier"
-    },
+    
+    "record_card_keywords": "Mots-clés:",
+    "record_card_organization": "Organisation:",
+    "record_card_published": "Publié:",
+    "record_card_relevancy": "Pertinence:",
+    "record_card_popularity": "Popularité:",
+    "record_card_view_record": "Voir le dossier",
 
     "footer_text": "GéoDécouverte, Centre canadien de cartographie et d’observation de la Terre, gouvernement du Canada, 2024–2025"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,3 +1,12 @@
 {
-    "website_title": "Démonstration de l’API de recherche sémantique pour GEO.ca"
+    "website_header": "Démonstration de l’API de recherche sémantique pour GEO.ca",
+    "semantic_search_description": "Les moteurs de recherche sémantiques surpassent la simple correspondance de mots-clés en interprétant l’intention et le contexte des requêtes. Contrairement aux recherches traditionnelles, la recherche sémantique traite le langage naturel et les requêtes complexes, en reconnaissant les synonymes et les variations. Nous avons affiné les modèles de transformateurs de phrases pour améliorer la pertinence de la recherche de métadonnées géospatiales. L’API de recherche sémantique est déployée à l’aide d’Amazon OpenSearch et d’Amazon SageMaker.",
+    "visit_github_call": "Visitez nos dépôts GitHub:",
+    "keyword_search": "Recherche par Mot-clé",
+    "semantic_search": "Recherche Sémantique",
+    "semantic_search_new": "Recherche Sémantique *Nouveau*",
+    "search_button": "Rechercher",
+    "parse_error": "Erreur d’analyse. Cette démonstration doit probablement être mise à jour vers la dernière API.",
+    "search_load_message": "Récupération des résultats de recherche…"
+
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,0 +1,3 @@
+{
+    "website_title": "Démonstration de l’API de recherche sémantique pour GEO.ca",
+}

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,3 +1,3 @@
 {
-    "website_title": "Démonstration de l’API de recherche sémantique pour GEO.ca",
+    "website_title": "Démonstration de l’API de recherche sémantique pour GEO.ca"
 }

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -1,6 +1,9 @@
+<script lang="ts">
+	import { m } from "$lib/paraglide/messages.js";
+</script>
 <footer class="fluid-container">
 	<hr />
-	<p>GeoDiscovery, Canada Centre for Mapping and Earth Observation, Government of Canada, 2024–2025</p>
+	<p>{m.footer_text()}</p>
 </footer>
 
 <style>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,3 +1,12 @@
+<script lang="ts">
+	import { getLocale, setLocale } from "$lib/paraglide/runtime.js";
+
+	
+	function switchLanguage(lang: 'en' | 'fr') {
+		setLocale(lang);
+		localStorage.setItem('locale', lang);
+	}
+</script>
 <header class="fluid-container">
 	<nav>
 		<ul id="cgp">
@@ -18,7 +27,7 @@
 				</details>
 			</li> -->
 			<li>
-				<button onclick={toggleLanguage}>
+				<button onclick={switchLanguage}>
 					{getLocale() === 'en' ? 'Français' : 'English'}
 				</button>
 			</li>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { getLocale, setLocale } from "$lib/paraglide/runtime.js";
-
 	
 	function toggleLanguage() {
 		const currentLocale = getLocale();
@@ -29,7 +28,7 @@
 				</details>
 			</li> -->
 			<li>
-				<button onclick={switchLanguage}>
+				<button onclick={toggleLanguage}>
 					{getLocale() === 'en' ? 'Français' : 'English'}
 				</button>
 			</li>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -2,9 +2,11 @@
 	import { getLocale, setLocale } from "$lib/paraglide/runtime.js";
 
 	
-	function switchLanguage(lang: 'en' | 'fr') {
-		setLocale(lang);
-		localStorage.setItem('locale', lang);
+	function toggleLanguage() {
+		const currentLocale = getLocale();
+		const newLocale = currentLocale === 'en' ? 'fr' : 'en';
+		setLocale(newLocale);
+		localStorage.setItem('locale', newLocale);
 	}
 </script>
 <header class="fluid-container">

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getLocale, setLocale } from "$lib/paraglide/runtime.js";
+	import { m } from "$lib/paraglide/messages.js";
 	
 	function toggleLanguage() {
 		const currentLocale = getLocale();
@@ -13,7 +14,7 @@
 		<ul id="cgp">
 			<li>
 				<img src="favicon.png" alt="CGP logo" />
-				Canadian Geospatial Platform
+				{m.header_text()}
 			</li>
 		</ul>
 		<ul>

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -18,6 +18,11 @@
 				</details>
 			</li> -->
 			<li>
+				<button onclick={toggleLanguage}>
+					{getLocale() === 'en' ? 'Français' : 'English'}
+				</button>
+			</li>
+			<li>
 				<details class="dropdown">
 					<summary> <i class="fa-brands fa-github"></i> GitHub </summary>
 					{#snippet githubRepo(repo)}

--- a/src/lib/components/RecordCard.svelte
+++ b/src/lib/components/RecordCard.svelte
@@ -13,6 +13,7 @@
 	let title = record[`title_${lang}`] ?? record.title;
 	let keywords = record[`keywords_${lang}`] ?? record.keywords;
 	let description = record[`description_${lang}`] ?? record.description;
+	let organization = record.organisation?.[lang] ?? record.organisation;
 
 	let thumbnailURL =
 		'https://app.geo.ca/result/' + lang + '/' +
@@ -61,7 +62,7 @@
 			<p><b>{m.record_card_keywords()}</b> {keywords}</p>
 		{/if}
 		{#if record.organisation}
-			<p><b>{m.record_card_organization()}</b> {record.organisation}</p>
+			<p><b>{m.record_card_organization()}</b> {organization}</p>
 		{/if}
 		<div class="grid">
 			{#if record.published}

--- a/src/lib/components/RecordCard.svelte
+++ b/src/lib/components/RecordCard.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
+	import { getLocale } from "$lib/paraglide/runtime.js";
+
 	interface Props {
 		record?: any;
 	}
 
 	let { record = {} as any }: Props = $props();
 
-	let lang = 'en';
+	let lang = getLocale();
 
 	let title = record[`title_${lang}`] ?? record.title;
 	let keywords = record[`keywords_${lang}`] ?? record.keywords;

--- a/src/lib/components/RecordCard.svelte
+++ b/src/lib/components/RecordCard.svelte
@@ -15,10 +15,10 @@
 	let description = record[`description_${lang}`] ?? record.description;
 
 	let thumbnailURL =
-		'https://app.geo.ca/result/{lang}/' +
+		'https://app.geo.ca/result/' + lang + '/' +
 		title.replace(/\W+/g, '-').toLowerCase() +
 		'?id=' + record.id +
-		'&lang={lang}';
+		'&lang=' + lang;
 
 	async function showPlaceholder(event) {
 		event.target.src =

--- a/src/lib/components/RecordCard.svelte
+++ b/src/lib/components/RecordCard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getLocale } from "$lib/paraglide/runtime.js";
+	import { m } from "$lib/paraglide/messages.js";
 
 	interface Props {
 		record?: any;
@@ -14,10 +15,10 @@
 	let description = record[`description_${lang}`] ?? record.description;
 
 	let thumbnailURL =
-		'https://app.geo.ca/result/en/' +
+		'https://app.geo.ca/result/{lang}/' +
 		title.replace(/\W+/g, '-').toLowerCase() +
 		'?id=' + record.id +
-		'&lang=en';
+		'&lang={lang}';
 
 	async function showPlaceholder(event) {
 		event.target.src =
@@ -57,21 +58,21 @@
 	<h3>{record.row_num}. <a href={thumbnailURL} target="_blank">{title}</a></h3>
 	<div class="small">
 		{#if keywords}
-			<p><b>Keywords:</b> {keywords}</p>
+			<p><b>{m.record_card.keywords()}:</b> {keywords}</p>
 		{/if}
 		{#if record.organisation}
-			<p><b>Organization:</b> {record.organisation}</p>
+			<p><b>{m.record_card.organization()}:</b> {record.organisation}</p>
 		{/if}
 		<div class="grid">
 			{#if record.published}
-				<p><b>Published:</b> {record.published}</p>
+				<p><b>{m.record_card.published()}:</b> {record.published}</p>
 				<p>
 					{#if record.relevancy}
-						<b>Relevancy:</b>
+						<b>{m.record_card.Relevancy()}:</b>
 						{record.relevancy}{#if record.popularity};{/if}
 					{/if}
 					{#if record.popularity}
-						<b>Popularity:</b> {record.popularity}
+						<b>{m.record_card.Popularity()}:</b> {record.popularity}
 					{/if}
 				</p>
 			{/if}
@@ -79,7 +80,7 @@
 	</div>
 	<p class="description">{@html description.replaceAll('\\n', '<br />')}</p>
 	<!-- <p><strong>Extent:</strong> {item.extent}</p> -->
-	<button onclick={() => window.open(thumbnailURL)}> View record &rarr; </button>
+	<button onclick={() => window.open(thumbnailURL)}> {m.record_card.view_record()} &rarr; </button>
 </article>
 
 <style>

--- a/src/lib/components/RecordCard.svelte
+++ b/src/lib/components/RecordCard.svelte
@@ -58,21 +58,21 @@
 	<h3>{record.row_num}. <a href={thumbnailURL} target="_blank">{title}</a></h3>
 	<div class="small">
 		{#if keywords}
-			<p><b>{m.record_card.keywords()}:</b> {keywords}</p>
+			<p><b>{m.record_card_keywords()}:</b> {keywords}</p>
 		{/if}
 		{#if record.organisation}
-			<p><b>{m.record_card.organization()}:</b> {record.organisation}</p>
+			<p><b>{m.record_card_organization()}:</b> {record.organisation}</p>
 		{/if}
 		<div class="grid">
 			{#if record.published}
-				<p><b>{m.record_card.published()}:</b> {record.published}</p>
+				<p><b>{m.record_card_published()}:</b> {record.published}</p>
 				<p>
 					{#if record.relevancy}
-						<b>{m.record_card.Relevancy()}:</b>
+						<b>{m.record_card_Relevancy()}:</b>
 						{record.relevancy}{#if record.popularity};{/if}
 					{/if}
 					{#if record.popularity}
-						<b>{m.record_card.Popularity()}:</b> {record.popularity}
+						<b>{m.record_card_Popularity()}:</b> {record.popularity}
 					{/if}
 				</p>
 			{/if}
@@ -80,7 +80,7 @@
 	</div>
 	<p class="description">{@html description.replaceAll('\\n', '<br />')}</p>
 	<!-- <p><strong>Extent:</strong> {item.extent}</p> -->
-	<button onclick={() => window.open(thumbnailURL)}> {m.record_card.view_record()} &rarr; </button>
+	<button onclick={() => window.open(thumbnailURL)}> {m.record_card_view_record()} &rarr; </button>
 </article>
 
 <style>

--- a/src/lib/components/RecordCard.svelte
+++ b/src/lib/components/RecordCard.svelte
@@ -68,11 +68,11 @@
 				<p><b>{m.record_card_published()}:</b> {record.published}</p>
 				<p>
 					{#if record.relevancy}
-						<b>{m.record_card_Relevancy()}:</b>
+						<b>{m.record_card_relevancy()}:</b>
 						{record.relevancy}{#if record.popularity};{/if}
 					{/if}
 					{#if record.popularity}
-						<b>{m.record_card_Popularity()}:</b> {record.popularity}
+						<b>{m.record_card_popularity()}:</b> {record.popularity}
 					{/if}
 				</p>
 			{/if}

--- a/src/lib/components/RecordCard.svelte
+++ b/src/lib/components/RecordCard.svelte
@@ -58,21 +58,21 @@
 	<h3>{record.row_num}. <a href={thumbnailURL} target="_blank">{title}</a></h3>
 	<div class="small">
 		{#if keywords}
-			<p><b>{m.record_card_keywords()}:</b> {keywords}</p>
+			<p><b>{m.record_card_keywords()}</b> {keywords}</p>
 		{/if}
 		{#if record.organisation}
-			<p><b>{m.record_card_organization()}:</b> {record.organisation}</p>
+			<p><b>{m.record_card_organization()}</b> {record.organisation}</p>
 		{/if}
 		<div class="grid">
 			{#if record.published}
-				<p><b>{m.record_card_published()}:</b> {record.published}</p>
+				<p><b>{m.record_card_published()}</b> {record.published}</p>
 				<p>
 					{#if record.relevancy}
-						<b>{m.record_card_relevancy()}:</b>
+						<b>{m.record_card_relevancy()}</b>
 						{record.relevancy}{#if record.popularity};{/if}
 					{/if}
 					{#if record.popularity}
-						<b>{m.record_card_popularity()}:</b> {record.popularity}
+						<b>{m.record_card_popularity()}</b> {record.popularity}
 					{/if}
 				</p>
 			{/if}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -23,10 +23,9 @@ export const load = async () => {
             password: true
           }
         },
+        override_display_language: getLocale() === 'fr' ? 'fr-CA' : 'en'
       });
-      posthog.set_config({
-          override_display_language: "fr-ca"
-      });
+      console.log(posthog.config);
     }
   }
   return;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -24,9 +24,9 @@ export const load = async () => {
           }
         },
       });
-      posthog.setPersonProperties({
-          $locale: 'fr-ca' // Sets the locale property for this visitor
-      })
+      posthog.set_config({
+          override_display_language: "fr-ca"
+      });
     }
   }
   return;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -30,4 +30,3 @@ export const load = async () => {
 };
 
 export const _frontmatter = {}
-export default posthog

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -24,6 +24,7 @@ export const load = async () => {
           }
         },
       });
+      posthog.reset()
     }
   }
   return;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -23,11 +23,7 @@ export const load = async () => {
             password: true
           }
         },
-        loaded: (posthog) => {
-            posthog.register({
-              locale: getLocale()
-            });
-          }
+        overrideDisplayLanguage: getLocale() === 'fr' ? 'fr-ca' : 'en'
       });
     }
   }

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -7,6 +7,7 @@ import "posthog-js/dist/surveys";
 import "posthog-js/dist/tracing-headers";
 import "posthog-js/dist/web-vitals";
 import posthog from 'posthog-js';
+import { getLocale } from "$lib/paraglide/runtime.js";
 
 import { browser } from '$app/environment';
 
@@ -21,7 +22,8 @@ export const load = async () => {
           maskInputOptions: {
             password: true
           }
-        }
+        },
+        locale: getLocale()
       });
     }
   }

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -23,7 +23,11 @@ export const load = async () => {
             password: true
           }
         },
-        locale: getLocale()
+        loaded: (posthog) => {
+            posthog.register({
+              locale: getLocale()
+            });
+          }
       });
     }
   }

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -24,11 +24,9 @@ export const load = async () => {
           }
         },
       });
-      posthog.onSurveysLoaded(() => {
-        posthog.getActiveMatchingSurveys((surveys) => {
+      posthog.getActiveMatchingSurveys((surveys) => {
           console.log(JSON.stringify(surveys, null, 2));
         });
-      });
     }
   }
   return;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -24,9 +24,6 @@ export const load = async () => {
           }
         },
       });
-      posthog.getActiveMatchingSurveys((surveys) => {
-          console.log(JSON.stringify(surveys, null, 2));
-        });
     }
   }
   return;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -23,9 +23,12 @@ export const load = async () => {
             password: true
           }
         },
-        override_display_language: getLocale() === 'fr' ? 'fr-CA' : 'en'
       });
-      console.log(posthog.config);
+      posthog.onSurveysLoaded(() => {
+        posthog.getActiveMatchingSurveys((surveys) => {
+          console.log(JSON.stringify(surveys, null, 2));
+        });
+      });
     }
   }
   return;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -23,8 +23,10 @@ export const load = async () => {
             password: true
           }
         },
-        surveyLanguage: getLocale() === 'fr' ? 'fr-ca' : 'en'
       });
+      posthog.setPersonProperties({
+          $locale: 'fr-ca' // Sets the locale property for this visitor
+      })
     }
   }
   return;

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -7,7 +7,6 @@ import "posthog-js/dist/surveys";
 import "posthog-js/dist/tracing-headers";
 import "posthog-js/dist/web-vitals";
 import posthog from 'posthog-js';
-import { getLocale } from "$lib/paraglide/runtime.js";
 
 import { browser } from '$app/environment';
 
@@ -31,3 +30,4 @@ export const load = async () => {
 };
 
 export const _frontmatter = {}
+export default posthog

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -23,7 +23,7 @@ export const load = async () => {
             password: true
           }
         },
-        overrideDisplayLanguage: getLocale() === 'fr' ? 'fr-ca' : 'en'
+        surveyLanguage: getLocale() === 'fr' ? 'fr-ca' : 'en'
       });
     }
   }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,12 +5,21 @@
 	import Footer from '$lib/components/Footer.svelte';
 
 	let query = $state('');
-	
+
+	// Define dropdown options for search modes
 	const searchOptions = [
 		{ value: 'keyword_search', label: 'Keyword Search' },
 		{ value: 'semantic_search', label: 'Semantic Search' },
 		{ value: 'semantic_search_new', label: 'Semantic Search *New*' }
 	];
+
+	// Define a mapping of search modes to their corresponding API endpoints
+	type SearchEngine = 'keyword_search' | 'semantic_search' | 'semantic_search_new';
+	const engineApiMap: Record<SearchEngine, (query: string) => string> = {
+		keyword_search: (q) => `https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`,
+		semantic_search: (q) => `https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`,
+		semantic_search_new: (q) => `https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
+	};
 
 	let rightMode = $state(searchOptions[0].value);
 	let leftMode = $state(searchOptions[1].value);
@@ -19,28 +28,34 @@
 		searchOptions.map(o => [o.value, o.label])
 	);
 	
-	let keywordSearchURL = $derived(
-		`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
-	);
-	let semanticSearchURL = $derived(
-		`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
-	);
-	let keywordPromise = $state.raw({} as Promise<any>);
-	let semanticPromise = $state.raw({} as Promise<any>);
+	// let keywordSearchURL = $derived(
+	// 	`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
+	// );
+	// let semanticSearchURL = $derived(
+	// 	`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
+	// );
+	let promiseLeft = $state.raw({} as Promise<any>);
+	let promiseRight = $state.raw({} as Promise<any>);
 	let searchInitiated = $state(false);
 
-	async function fetchKeywordSearchResults(query: string): Promise<any> {
-		const res = await fetch(keywordSearchURL);
-		console.log(res);
+	async function fetchSearchResults(url: string): Promise<any> {
+		const res = await fetch(url);
 		const data = await res.json();
 		return data;
 	}
 
-	async function fetchSemanticSearchResults(query: string): Promise<any> {
-		const res = await fetch(semanticSearchURL);
-		const data = await res.json();
-		return data;
-	}
+	// async function fetchKeywordSearchResults(query: string): Promise<any> {
+	// 	const res = await fetch(keywordSearchURL);
+	// 	console.log(res);
+	// 	const data = await res.json();
+	// 	return data;
+	// }
+
+	// async function fetchSemanticSearchResults(query: string): Promise<any> {
+	// 	const res = await fetch(semanticSearchURL);
+	// 	const data = await res.json();
+	// 	return data;
+	// }
 
 	async function handleSearch(event: Event) {
 		event.preventDefault();
@@ -49,13 +64,17 @@
 			return;
 		}
 		searchInitiated = true;
-		keywordPromise = fetchKeywordSearchResults(query);
-		semanticPromise = fetchSemanticSearchResults(query);
+
+		const urlLeft = $derived(engineApiMap[leftMode](query));
+		const urlRight = $derived(engineApiMap[rightMode](query));
+
+		promiseLeft = fetchSearchResults(urlLeft);
+		promiseRight = fetchSearchResults(urlRight);
 	}
 
 	function clearSearchResults() {
-		keywordPromise = Promise.resolve({});
-		semanticPromise = Promise.resolve({});
+		promiseLeft = Promise.resolve({});
+		promiseRight = Promise.resolve({});
 		searchInitiated = false;
 	}
 
@@ -152,8 +171,8 @@
 				<div>
 					<h2>{searchOptionLabels[leftMode]} results</h2>
 					<!-- <p>Sorted by relevancy</p> -->
-					{@render showSearchURL(semanticSearchURL)}
-					{#await semanticPromise}
+					{@render showSearchURL($derived(engineApiMap[leftMode](query)))}
+					{#await promiseLeft}
 						{@render loadingResults()}
 					{:then data}
 						{#if data.response && data.response.total_hits > 0}
@@ -180,8 +199,8 @@
 				<div>
 					<h2>{searchOptionLabels[rightMode]} results</h2>
 					<!-- <p>Sorted by popularity (relevancy not available)</p> -->
-					{@render showSearchURL(keywordSearchURL)}
-					{#await keywordPromise}
+					{@render showSearchURL($derived(engineApiMap[rightMode](query)))}
+					{#await promiseRight}
 						{@render loadingResults()}
 					{:then data}
 						{#if data.Count > 0}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -146,10 +146,7 @@
 				bind:value={query}
 				oninput={clearSearchResults}
 			/>
-			<input type="submit" value={m.search_button()} id="search-submit" 
-				class:lang-en={getLocale() === "en"}
-				class:lang-fr={getLocale() === "fr"}
-			/>
+			<input type="submit" value={m.search_button()} id="search-submit" />
 		</form>
 	</section>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -131,7 +131,7 @@
 
 	<section class="container">
 		<form role="comparison" class="side-by-side">
-			<select bind:value={leftMode} onchange={refreshSearchResults}>
+			<select bind:value={leftMode} onchange={refreshSearchResults} class="select-search-mode">
 				{#each searchOptions as option}
 					<option value={option.value}>
 						{option.label}
@@ -139,7 +139,7 @@
 				{/each}
 			</select>
 			<em style="position:relative; top:-1px;">VS</em>
-			<select bind:value={rightMode} onchange={refreshSearchResults}>
+			<select bind:value={rightMode} onchange={refreshSearchResults} class="select-search-mode">
 				{#each searchOptions as option}
 					<option value={option.value}> {option.label} </option>
 				{/each}
@@ -154,7 +154,7 @@
 				bind:value={query}
 				oninput={clearSearchResults}
 			/>
-			<input type="submit" value="Search" />
+			<input type="submit" value="Search" id="search-submit" />
 		</form>
 	</section>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -79,15 +79,15 @@
 		searchInitiated = false;
 	}
 
-	function refreshSearchResults(event: Event) {
-		console.log("Set comparison");
-		clearSearchResults();
+	// function refreshSearchResults(event: Event) {
+	// 	console.log("Set comparison");
+	// 	clearSearchResults();
 
-		if (query.trim()) {
-			handleSearch(event);
-		}
-		console.log("Done.");
-	}
+	// 	if (query.trim()) {
+	// 		handleSearch(event);
+	// 	}
+	// 	console.log("Done.");
+	// }
 </script>
 
 <svelte:head>
@@ -133,7 +133,7 @@
 
 	<section class="container">
 		<form role="comparison" class="side-by-side">
-			<select bind:value={leftMode} onchange={refreshSearchResults} class="select-search-mode">
+			<select bind:value={leftMode} onchange={clearSearchResults} class="select-search-mode">
 				{#each searchOptions as option}
 					<option value={option.value}>
 						{option.label}
@@ -141,7 +141,7 @@
 				{/each}
 			</select>
 			<em style="position:relative; top:-1px;">VS</em>
-			<select bind:value={rightMode} onchange={refreshSearchResults} class="select-search-mode">
+			<select bind:value={rightMode} onchange={clearSearchResults} class="select-search-mode">
 				{#each searchOptions as option}
 					<option value={option.value}> {option.label} </option>
 				{/each}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,14 +3,7 @@
 	import { version } from '$app/environment';
 	import RecordCard from '$lib/components/RecordCard.svelte';
 	import Footer from '$lib/components/Footer.svelte';
-	import { m } from "../paraglide/messages.js";
-	import { setLocale, getLocale } from "../paraglide/runtime.js";
-
-	// Language configuration 
-	function switchLanguage(lang: 'en' | 'fr') {
-		setLocale(lang);
-		localStorage.setItem('locale', lang);
-	}
+	import { m } from "$lib/paraglide/messages.js";
 
 	let query = $state('');
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -44,6 +44,10 @@
 		semanticPromise = Promise.resolve({});
 		searchInitiated = false;
 	}
+
+	function setComparison() {
+		console.log("Set comparison")
+	}
 </script>
 
 <svelte:head>
@@ -98,6 +102,24 @@
 				oninput={clearSearchResults}
 			/>
 			<input type="submit" value="Search" />
+		</form>
+	</section>
+
+	<section class="container">
+		<form role="versus" onsubmit={setComparison} oninput={clearSearchResults}>
+		<select bind:value={right-mode}>
+			<option value="keyword_search">Keyword Search</option>
+			<option value="semantic_search_existing">Semantic Search</option>
+			<option value="semantic_search_new">Semantic Search *New*</option>
+		</select>
+		<em> VS </em>
+		<select bind:value={left-mode} oninput={clearSearchResults}>
+			<option value="keyword_search">Keyword Search</option>
+			<option value="semantic_search_existing">Semantic Search</option>
+			<option value="semantic_search_new">Semantic Search *New*</option>
+		</select>
+		<br>
+		<input type="submit" value="Search" />
 		</form>
 	</section>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,7 +18,7 @@
 	// Define a mapping of search modes to their corresponding API endpoints
 	type SearchEngine = 'keyword_search' | 'semantic_search' | 'semantic_search_new';
 	const searchApiMap: Record<SearchEngine, (query: string) => string> = {
-		keyword_search: (q) => `https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(q)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`,
+		keyword_search: (q) => `https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(q)}&keyword_only=true&lang=${getLocale()}&min=1&max=10&sort=popularity-desc`,
 		semantic_search: (q) => `https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(q)}`,
 		semantic_search_new: (q) => `https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(q)}`
 	};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,25 +5,7 @@
 	import Footer from '$lib/components/Footer.svelte';
 
 	let query = $state('');
-
-	const searchModeMapper = {
-		'keyword_search': {
-			'url': $derived(
-				`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
-			)
-		},
-		'semantic_search': {
-			'url': $derived(
-				`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
-			)
-		},
-		'semantic_search_new': {
-			'url': $derived(
-				`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
-			)
-		},
-	}
-
+	
 	const searchOptions = [
 		{ value: 'keyword_search', label: 'Keyword Search' },
 		{ value: 'semantic_search', label: 'Semantic Search' },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -132,7 +132,7 @@
 					</option>
 				{/each}
 			</select>
-			<em style="position:relative; top:-1px;">VS</em>
+			<em style="position:relative; top:-1px;">|</em>
 			<select bind:value={rightMode} onchange={clearSearchResults} class="select-search-mode">
 				{#each searchOptions as option}
 					<option value={option.value}> {option.label} </option>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
 	let query = $state('');
 	let leftMode = $state('');
 	let rigthMode = $state('');
-	let query = $state('');
+	
 	let keywordSearchURL = $derived(
 		`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
 	);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,12 +30,6 @@
 		searchOptions.map(o => [o.value, o.label])
 	);
 	
-	// let keywordSearchURL = $derived(
-	// 	`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
-	// );
-	// let semanticSearchURL = $derived(
-	// 	`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
-	// );
 	let promiseLeft = $state.raw({} as Promise<any>);
 	let promiseRight = $state.raw({} as Promise<any>);
 	let searchInitiated = $state(false);
@@ -45,19 +39,6 @@
 		const data = await res.json();
 		return data;
 	}
-
-	// async function fetchKeywordSearchResults(query: string): Promise<any> {
-	// 	const res = await fetch(keywordSearchURL);
-	// 	console.log(res);
-	// 	const data = await res.json();
-	// 	return data;
-	// }
-
-	// async function fetchSemanticSearchResults(query: string): Promise<any> {
-	// 	const res = await fetch(semanticSearchURL);
-	// 	const data = await res.json();
-	// 	return data;
-	// }
 	
 	// Derive the search URLs based on the selected modes and query
 	const urlLeft = $derived(searchApiMap[leftMode](query));
@@ -80,17 +61,7 @@
 		promiseRight = Promise.resolve({});
 		searchInitiated = false;
 	}
-
-	// function refreshSearchResults(event: Event) {
-	// 	console.log("Set comparison");
-	// 	clearSearchResults();
-
-	// 	if (query.trim()) {
-	// 		handleSearch(event);
-	// 	}
-	// 	console.log("Done.");
-	// }
-	console.log(getLocale());
+	
 </script>
 
 <svelte:head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,9 +10,9 @@
 
 	// Define dropdown options for search modes
 	const searchOptions = [
-		{ value: 'keyword_search', label: 'Keyword Search' },
-		{ value: 'semantic_search', label: 'Semantic Search' },
-		{ value: 'semantic_search_new', label: 'Semantic Search *New*' }
+		{ value: 'keyword_search', label: m.keyword_search() },
+		{ value: 'semantic_search', label: m.semantic_search() },
+		{ value: 'semantic_search_new', label: m.semantic_search_new() }
 	];
 
 	// Define a mapping of search modes to their corresponding API endpoints
@@ -94,7 +94,7 @@
 </script>
 
 <svelte:head>
-	<title>{m.website_title()}</title>
+	<title>Semantic Search API Demo for GEO.ca</title>
 	<link
 		rel="stylesheet"
 		href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"
@@ -108,24 +108,20 @@
 
 <main class="fluid-container">
 	<section class="container" id="title">
-		<h1>Semantic Search API Demo for GEO.ca</h1>
-		<p>Front-end demo v{version} (2025-04-30), work-in-progress</p>
+		<h1>{m.website_header()}</h1>
+		<p>v{version} (2025-04-30)</p>
 	</section>
 
 	<section class="container grid">
 		<article>
-			Semantic search engines surpass simple keyword matching by interpreting the intent and context
-			of queries. Unlike traditional searches, semantic search processes natural language and
-			complex requests, recognizing synonyms and variations. We fine-tuned Sentence-Transformer
-			models to enhance search relevance for geospatial metadata. The semantic search API is
-			deployed using Amazon OpenSearch and Amazon SageMaker.
+			{m.semantic_search_description()}
 		</article>
 
 		{#snippet githubRepo(repo)}
 			<a href="https://github.com/Canadian-Geospatial-Platform/{repo}" target="_blank">{repo}</a>
 		{/snippet}
 		<article>
-			<p>Visit our GitHub repositories:</p>
+			<p>{m.visit_github_call()}</p>
 			<ul class="github-repo">
 				<li>{@render githubRepo('semantic-search-model-evaluation')}</li>
 				<li>{@render githubRepo('semantic-search-with-amazon-opensearch')}</li>
@@ -159,7 +155,7 @@
 				bind:value={query}
 				oninput={clearSearchResults}
 			/>
-			<input type="submit" value="Search" id="search-submit" />
+			<input type="submit" value={m.search_button()} id="search-submit" />
 		</form>
 	</section>
 
@@ -207,7 +203,7 @@
 							{:else if data.response && data.response.total_hits === 0}
 								<p>No result</p>
 							{:else}
-								<p class="error">Parse error.  This demo likely needs to be updated to the latest API.</p>
+								<p class="error">{m.parse_error()}</p>
 								<p>Returned results in JSON format:</p>
 								<p class="error">{data.message}</p>
 								<textarea rows="50" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
@@ -251,7 +247,7 @@
 							{:else if data.response && data.response.total_hits === 0}
 								<p>No result</p>
 							{:else}
-								<p class="error">Parse error.  This demo likely needs to be updated to the latest API.</p>
+								<p class="error">{m.parse_error()}</p>
 								<p>Returned results in JSON format:</p>
 								<p class="error">{data.message}</p>
 								<textarea rows="50" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -65,14 +65,14 @@
 		promiseLeft = fetchSearchResults(urlLeft);
 		promiseRight = fetchSearchResults(urlRight);
 		
-		setTimeout(() => {
-			if (getLocale() == 'en') {
-				posthog.displaySurvey('019f37a0-7c58-0000-abd2-2c3958e39793')
-			}
-			else {
-				posthog.displaySurvey('019f3cf9-c8ba-0000-5d0d-31211fca0025')
-			}
-		}, 5000)
+		// setTimeout(() => {
+		// 	if (getLocale() == 'en') {
+		// 		posthog.displaySurvey('019f37a0-7c58-0000-abd2-2c3958e39793')
+		// 	}
+		// 	else {
+		// 		posthog.displaySurvey('019f3cf9-c8ba-0000-5d0d-31211fca0025')
+		// 	}
+		// }, 5000)
 	}
 
 	function clearSearchResults() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -106,7 +106,6 @@
 	</section>
 
 	<section class="container">
-		<p>Choose the search modes you would like to compare</p>
 		<form role="comparison" class="side-by-side">
 			<select bind:value={leftMode} onchange={refreshSearchResults}>
 				{#each searchOptions as option}
@@ -115,16 +114,13 @@
 					</option>
 				{/each}
 			</select>
-			<em>VS</em>
+			<em style="position:relative; top:-2rem;">VS</em>
 			<select bind:value={rightMode} onchange={refreshSearchResults}>
 				{#each searchOptions as option}
 					<option value={option.value}> {option.label} </option>
 				{/each}
 			</select>
 		</form>
-	</section>
-
-	<section class="container">
 		<form role="search" onsubmit={handleSearch}>
 			<input
 				aria-label="Search"
@@ -227,6 +223,9 @@
 		margin-left: auto;
 		margin-right: auto;
 		width: max-content;
+		color: var(--pico-primary);
+    	font-weight: bold;
+		top: -1rem;
 	}
 	
 	.side-by-side select {
@@ -235,8 +234,6 @@
 		cursor: pointer;
 		background-color: transparent;
 		text-transform: capitalize;
-		color: var(--pico-primary);
-    	font-weight: bold;
 	}
 
 	p.search-url {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -223,13 +223,17 @@
 	.side-by-side {
 		display: flex;
 		align-items: center;
-		gap: 1rem;
+		gap: 2rem;
+		margin-left: 5rem;
+    	margin-right: 5rem;
 	}
 	
 	.side-by-side select {
 		border: None;
 		padding-right: 2rem;
 		cursor: pointer;
+		background-color: none;
+		text-transform: capitalize;
 	}
 
 	p.search-url {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,10 +3,10 @@
 	import { version } from '$app/environment';
 	import RecordCard from '$lib/components/RecordCard.svelte';
 	import Footer from '$lib/components/Footer.svelte';
-	import * as m from '../paraglide/messages';
+	import * as m from '$lib/paraglide/messages.js';
 
 	// Language configuration 
-	import { setLocale } from '../paraglide/runtime';
+	import { setLocale } from '$lib/paraglide/runtime.js';
 	function switchLanguage(lang: 'en' | 'fr') {
 		setLocale(lang);
 		localStorage.setItem('locale', lang);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -83,7 +83,9 @@
 		console.log("Set comparison");
 		clearSearchResults();
 
-		handleSearch(event);
+		if (query.trim()) {
+			handleSearch(event);
+		}
 		console.log("Done.");
 	}
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -135,14 +135,14 @@
 	{/snippet}
 
 	{#snippet loadingResults()}
-		<p aria-busy="true">Fetching search results…</p>
+		<p aria-busy="true">{m.search_load_message()}</p>
 	{/snippet}
 
 	<section>
 		{#if searchInitiated}
 			<div class="grid">
 				<div>
-					<h2>{searchOptionLabels[leftMode]} results</h2>
+					<h2>{searchOptionLabels[leftMode]} {m.results_text()}</h2>
 					<!-- <p>Sorted by relevancy</p> -->
 					{@render showSearchURL(urlLeft)}
 					{#await promiseLeft}
@@ -150,7 +150,7 @@
 					{:then data}
 						{#if leftMode === 'keyword_search'}
 							{#if data.Count > 0}
-								<p class="center">1 – {data.Count} of {data.Items[0].total} records</p>
+								<p class="center">{m.records_retrieved_text({ data_count: data.Count, total: data.Items[0].total })}</p>
 								<div class="search-results">
 									{#each data.Items as record (record.row_num)}
 										<RecordCard {record} />
@@ -175,18 +175,18 @@
 								<p>No result</p>
 							{:else}
 								<p class="error">{m.parse_error()}</p>
-								<p>Returned results in JSON format:</p>
+								<p>{m.parse_error_json_output()}</p>
 								<p class="error">{data.message}</p>
 								<textarea rows="50" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
 							{/if}
 						{/if}
 					{:catch error}
-						<p class="error">Error: {error}</p>
+						<p class="error">{m.error_label()} {error}</p>
 					{/await}
 				</div>
 
 				<div>
-					<h2>{searchOptionLabels[rightMode]} results</h2>
+					<h2>{searchOptionLabels[rightMode]} {m.results_text()}</h2>
 					<!-- <p>Sorted by popularity (relevancy not available)</p> -->
 					{@render showSearchURL(urlRight)}
 					{#await promiseRight}
@@ -194,7 +194,7 @@
 					{:then data}
 						{#if rightMode === 'keyword_search'}
 							{#if data.Count > 0}
-								<p class="center">1 – {data.Count} of {data.Items[0].total} records</p>
+								<p class="center">{m.records_retrieved_text({ data_count: data.Count, total: data.Items[0].total })}</p>
 								<div class="search-results">
 									{#each data.Items as record (record.row_num)}
 										<RecordCard {record} />
@@ -219,13 +219,13 @@
 								<p>No result</p>
 							{:else}
 								<p class="error">{m.parse_error()}</p>
-								<p>Returned results in JSON format:</p>
+								<p>{m.parse_error_json_output()}</p>
 								<p class="error">{data.message}</p>
 								<textarea rows="50" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
 							{/if}
 						{/if}
 					{:catch error}
-						<p class="error">Error: {error}</p>
+						<p class="error">{m.error_label()} {error}</p>
 					{/await}
 				</div>
 			</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -53,14 +53,19 @@
 			return;
 		}
 		searchInitiated = true;
+
+		models_invoked = [leftMode, rightMode];
 		
 		posthog.register({
-			search_query: query
+			search_query: query,
+			locale: getLocale(),
+			models: models_invoked.sort()
 		})
 		
 		posthog.capture('search_performed', {
-			query,
+			search_query: query,
 			locale: getLocale(),
+			models: models_invoked.sort(),
 			leftMode,
 			rightMode,
 			timestamp: new Date().toISOString(),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -109,8 +109,8 @@
 	</section>
 
 	<section class="container">
-		<form role="versus" onsubmit={setComparison} oninput={clearSearchResults}>
-		<select bind:value={rightMode}>
+		<form role="comparison" onsubmit={setComparison}>
+		<select bind:value={rightMode} oninput={clearSearchResults}>
 			<option value="keyword_search">Keyword Search</option>
 			<option value="semantic_search_existing">Semantic Search</option>
 			<option value="semantic_search_new">Semantic Search *New*</option>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,7 +54,7 @@
 		}
 		searchInitiated = true;
 
-		models_invoked = [leftMode, rightMode];
+		const models_invoked = [leftMode, rightMode];
 		
 		posthog.register({
 			search_query: query,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -58,15 +58,17 @@
 			query,
 		})
 
-		if (getLocale() == 'en') {
-			posthog.displaySurvey('019f37a0-7c58-0000-abd2-2c3958e39793')
-		}
-		else {
-			posthog.displaySurvey('019f3cf9-c8ba-0000-5d0d-31211fca0025')
-		}
-
 		promiseLeft = fetchSearchResults(urlLeft);
 		promiseRight = fetchSearchResults(urlRight);
+		
+		setTimeout(() => {
+			if (getLocale() == 'en') {
+				posthog.displaySurvey('019f37a0-7c58-0000-abd2-2c3958e39793')
+			}
+			else {
+				posthog.displaySurvey('019f3cf9-c8ba-0000-5d0d-31211fca0025')
+			}
+		}, 5000)
 	}
 
 	function clearSearchResults() {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,7 +6,7 @@
 	import { m } from "$lib/paraglide/messages.js";
 	import { getLocale } from "$lib/paraglide/runtime.js";
 	import { get } from 'svelte/store';
-	import posthog from './+layout.ts';
+	import posthog from 'posthog-js';
 
 	let query = $state('');
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,10 +3,10 @@
 	import { version } from '$app/environment';
 	import RecordCard from '$lib/components/RecordCard.svelte';
 	import Footer from '$lib/components/Footer.svelte';
-	import * as m from '../paraglide/messages.js';
+	import { m } from "../paraglide/messages.js";
+	import { setLocale } from "../paraglide/runtime.js";
 
 	// Language configuration 
-	import { setLocale } from '../paraglide/runtime.js';
 	function switchLanguage(lang: 'en' | 'fr') {
 		setLocale(lang);
 		localStorage.setItem('locale', lang);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -57,7 +57,7 @@
 			query,
 		})
 
-		if getLocale() == 'en') {
+		if (getLocale() == 'en') {
 			posthog.displaySurvey('019f37a0-7c58-0000-abd2-2c3958e39793')
 		}
 		else {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -106,20 +106,7 @@
 	</section>
 
 	<section class="container">
-		<form role="search" onsubmit={handleSearch}>
-			<input
-				aria-label="Search"
-				name="search"
-				type="search"
-				autofocus
-				bind:value={query}
-				oninput={clearSearchResults}
-			/>
-			<input type="submit" value="Search" />
-		</form>
-	</section>
-
-	<section class="container">
+		<p>Choose the search modes you would like to compare</p>
 		<form role="comparison" class="side-by-side">
 			<select bind:value={leftMode} onchange={refreshSearchResults}>
 				{#each searchOptions as option}
@@ -134,6 +121,20 @@
 					<option value={option.value}> {option.label} </option>
 				{/each}
 			</select>
+		</form>
+	</section>
+
+	<section class="container">
+		<form role="search" onsubmit={handleSearch}>
+			<input
+				aria-label="Search"
+				name="search"
+				type="search"
+				autofocus
+				bind:value={query}
+				oninput={clearSearchResults}
+			/>
+			<input type="submit" value="Search" />
 		</form>
 	</section>
 
@@ -222,7 +223,13 @@
 	.side-by-side {
 		display: flex;
 		align-items: center;
-		gap: 1rem; /* optional spacing */
+		gap: 1rem;
+	}
+	
+	.side-by-side select {
+		border: None;
+		padding-right: 2rem;
+		cursor: pointer;
 	}
 
 	p.search-url {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import RecordCard from '$lib/components/RecordCard.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 	import { m } from "$lib/paraglide/messages.js";
+	import { getLocale } from "$lib/paraglide/runtime.js";
 
 	let query = $state('');
 
@@ -89,6 +90,7 @@
 	// 	}
 	// 	console.log("Done.");
 	// }
+	console.log(getLocale());
 </script>
 
 <svelte:head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -122,7 +122,7 @@
 	</section>
 
 	<section class="container">
-		<form role="comparison" class="side-by-side">
+		<form class="side-by-side">
 			<select bind:value={leftMode} onchange={clearSearchResults} class="select-search-mode">
 				{#each searchOptions as option}
 					<option value={option.value}>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -80,6 +80,8 @@
 		promiseLeft = Promise.resolve({});
 		promiseRight = Promise.resolve({});
 		searchInitiated = false;
+
+      	posthog.reset()
 	}
 	
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -114,7 +114,7 @@
 					</option>
 				{/each}
 			</select>
-			<em style="position:relative; top:-0.5rem;">VS</em>
+			<em style="position:relative; top:-1px;">VS</em>
 			<select bind:value={rightMode} onchange={refreshSearchResults}>
 				{#each searchOptions as option}
 					<option value={option.value}> {option.label} </option>
@@ -223,11 +223,11 @@
 		margin-left: auto;
 		margin-right: auto;
 		width: max-content;
-		color: var(--pico-primary);
+		color: var(--pico-secondary);
     	font-weight: bold;
 		background-color: var(--pico-secondary-focus);
-		border-top-left-radius: 10px;
-		border-top-right-radius: 10px;
+		border-top-left-radius: 0.5rem;
+		border-top-right-radius: 0.5rem;
 	}
 	
 	.side-by-side select {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,15 +6,21 @@
 
 	let query = $state('');
 
-	
 	const searchOptions = [
 		{ value: 'keyword_search', label: 'Keyword Search' },
 		{ value: 'semantic_search', label: 'Semantic Search' },
 		{ value: 'semantic_search_new', label: 'Semantic Search *New*' }
 	];
 
-	let rightMode = $state(searchOptions[0]);
-	let leftMode = $state(searchOptions[1]);
+	let rightMode = $state(searchOptions[0].value);
+	const rightModeLabel = $derived(
+		searchOptions.find(option => option.value === rightMode)?.label ?? rightMode
+	);
+
+	let leftMode = $state(searchOptions[1].value);
+	const leftModeLabel = $derived(
+		searchOptions.find(option => option.value === leftMode)?.label ?? leftMode
+	);
 	
 	let keywordSearchURL = $derived(
 		`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
@@ -148,7 +154,7 @@
 		{#if searchInitiated}
 			<div class="grid">
 				<div>
-					<h2>{leftMode} results</h2>
+					<h2>{leftModeLabel} results</h2>
 					<!-- <p>Sorted by relevancy</p> -->
 					{@render showSearchURL(semanticSearchURL)}
 					{#await semanticPromise}
@@ -176,7 +182,7 @@
 				</div>
 
 				<div>
-					<h2>{rightMode} results</h2>
+					<h2>{rightModeLabel} results</h2>
 					<!-- <p>Sorted by popularity (relevancy not available)</p> -->
 					{@render showSearchURL(keywordSearchURL)}
 					{#await keywordPromise}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,6 +3,14 @@
 	import { version } from '$app/environment';
 	import RecordCard from '$lib/components/RecordCard.svelte';
 	import Footer from '$lib/components/Footer.svelte';
+	import * as m from '../paraglide/messages';
+
+	// Language configuration 
+	import { setLocale } from '../paraglide/runtime';
+	function switchLanguage(lang: 'en' | 'fr') {
+		setLocale(lang);
+		localStorage.setItem('locale', lang);
+	}
 
 	let query = $state('');
 
@@ -91,7 +99,7 @@
 </script>
 
 <svelte:head>
-	<title>Semantic Search API Demo for GEO.ca</title>
+	<title>{m.website_title()}</title>
 	<link
 		rel="stylesheet"
 		href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,19 +10,18 @@
 		'keyword_search': {
 			'url': $derived(
 				`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
-			);
+			)
 		},
 		'semantic_search': {
 			'url': $derived(
 				`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
-			);
+			)
 		},
 		'semantic_search_new': {
 			'url': $derived(
 				`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
-			);
+			)
 		},
-
 	}
 
 	const searchOptions = [

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,7 @@
 	import { m } from "$lib/paraglide/messages.js";
 	import { getLocale } from "$lib/paraglide/runtime.js";
 	import { get } from 'svelte/store';
+	import posthog from './+layout.ts';
 
 	let query = $state('');
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,13 +13,10 @@
 	];
 
 	let rightMode = $state(searchOptions[0].value);
-	const rightModeLabel = $derived(
-		searchOptions.find(option => option.value === rightMode)?.label ?? rightMode
-	);
-
 	let leftMode = $state(searchOptions[1].value);
-	const leftModeLabel = $derived(
-		searchOptions.find(option => option.value === leftMode)?.label ?? leftMode
+	
+	const searchOptionLabels = Object.fromEntries(
+		searchOptions.map(o => [o.value, o.label])
 	);
 	
 	let keywordSearchURL = $derived(
@@ -123,22 +120,20 @@
 	</section>
 
 	<section class="container">
-		<form role="comparison">
-		<select bind:value={leftMode} onchange={refreshSearchResults}>
-			{#each searchOptions as option}
-				<option value={option.value}>
-					{option.label}
-				</option>
-			{/each}
-		</select>
-		<em> VS </em>
-		<select bind:value={rightMode} onchange={refreshSearchResults}>
-			{#each searchOptions as option}
-				<option value={option.value}> {option.label} </option>
-			{/each}
-		</select>
-		<br>
-		<input type="submit" value="Search" />
+		<form role="comparison" class="side-by-side">
+			<select bind:value={leftMode} onchange={refreshSearchResults}>
+				{#each searchOptions as option}
+					<option value={option.value}>
+						{option.label}
+					</option>
+				{/each}
+			</select>
+			<em>VS</em>
+			<select bind:value={rightMode} onchange={refreshSearchResults}>
+				{#each searchOptions as option}
+					<option value={option.value}> {option.label} </option>
+				{/each}
+			</select>
 		</form>
 	</section>
 
@@ -154,7 +149,7 @@
 		{#if searchInitiated}
 			<div class="grid">
 				<div>
-					<h2>{leftModeLabel} results</h2>
+					<h2>{searchOptionLabels[leftMode]} results</h2>
 					<!-- <p>Sorted by relevancy</p> -->
 					{@render showSearchURL(semanticSearchURL)}
 					{#await semanticPromise}
@@ -182,7 +177,7 @@
 				</div>
 
 				<div>
-					<h2>{rightModeLabel} results</h2>
+					<h2>{searchOptionLabels[rightMode]} results</h2>
 					<!-- <p>Sorted by popularity (relevancy not available)</p> -->
 					{@render showSearchURL(keywordSearchURL)}
 					{#await keywordPromise}
@@ -223,6 +218,13 @@
 		font-size: 125%;
 		height: 4rem;
 	}
+	
+	.side-by-side {
+		display: flex;
+		align-items: center;
+		gap: 1rem; /* optional spacing */
+	}
+
 	p.search-url {
 		font-size: 0.8em;
 		overflow: hidden;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6,6 +6,25 @@
 
 	let query = $state('');
 
+	const searchModeMapper = {
+		'keyword_search': {
+			'url': $derived(
+				`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
+			);
+		},
+		'semantic_search': {
+			'url': $derived(
+				`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
+			);
+		},
+		'semantic_search_new': {
+			'url': $derived(
+				`https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
+			);
+		},
+
+	}
+
 	const searchOptions = [
 		{ value: 'keyword_search', label: 'Keyword Search' },
 		{ value: 'semantic_search', label: 'Semantic Search' },
@@ -59,8 +78,12 @@
 		searchInitiated = false;
 	}
 
-	function refreshSearchResults() {
-		console.log("Set comparison")
+	function refreshSearchResults(event: Event) {
+		console.log("Set comparison");
+		clearSearchResults();
+
+		handleSearch(event);
+		console.log("Done.");
 	}
 </script>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,10 +3,10 @@
 	import { version } from '$app/environment';
 	import RecordCard from '$lib/components/RecordCard.svelte';
 	import Footer from '$lib/components/Footer.svelte';
-	import * as m from '$lib/paraglide/messages.js';
+	import * as m from '../paraglide/messages.js';
 
 	// Language configuration 
-	import { setLocale } from '$lib/paraglide/runtime.js';
+	import { setLocale } from '../paraglide/runtime.js';
 	function switchLanguage(lang: 'en' | 'fr') {
 		setLocale(lang);
 		localStorage.setItem('locale', lang);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -126,7 +126,10 @@
 				bind:value={query}
 				oninput={clearSearchResults}
 			/>
-			<input type="submit" value={m.search_button()} id="search-submit" />
+			<input type="submit" value={m.search_button()} id="search-submit" 
+				class:lang-en={getLocale() === "en"}
+				class:lang-fr={getLocale() === "fr"}
+			/>
 		</form>
 	</section>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -164,7 +164,7 @@
 							{/if}
 						{:else}
 							{#if data.response && data.response.total_hits > 0}
-								<p class="center">1 – {data.response.returned_hits} of {data.response.total_hits} records</p>
+								<p class="center">{m.records_retrieved_text({ data_count: data.response.returned_hits, total: data.response.total_hits })}</p>
 								<div class="search-results">
 									{#each data.response.items as item (item.features[0].properties.row_num)}
 										{@const record = item.features[0].properties}
@@ -208,7 +208,7 @@
 							{/if}
 						{:else}
 							{#if data.response && data.response.total_hits > 0}
-								<p class="center">1 – {data.response.returned_hits} of {data.response.total_hits} records</p>
+								<p class="center">{m.records_retrieved_text({ data_count: data.response.returned_hits, total: data.response.total_hits })}</p>
 								<div class="search-results">
 									{#each data.response.items as item (item.features[0].properties.row_num)}
 										{@const record = item.features[0].properties}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -114,7 +114,7 @@
 					</option>
 				{/each}
 			</select>
-			<em style="position:relative; top:-2rem;">VS</em>
+			<em style="position:relative; top:-0.5rem;">VS</em>
 			<select bind:value={rightMode} onchange={refreshSearchResults}>
 				{#each searchOptions as option}
 					<option value={option.value}> {option.label} </option>
@@ -225,7 +225,9 @@
 		width: max-content;
 		color: var(--pico-primary);
     	font-weight: bold;
-		top: -1rem;
+		background-color: var(--pico-secondary-focus);
+		border-top-left-radius: 10px;
+		border-top-right-radius: 10px;
 	}
 	
 	.side-by-side select {
@@ -234,6 +236,7 @@
 		cursor: pointer;
 		background-color: transparent;
 		text-transform: capitalize;
+		margin: 1rem;
 	}
 
 	p.search-url {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -74,14 +74,6 @@
 		promiseLeft = fetchSearchResults(urlLeft);
 		promiseRight = fetchSearchResults(urlRight);
 		
-		// setTimeout(() => {
-		// 	if (getLocale() == 'en') {
-		// 		posthog.displaySurvey('019f37a0-7c58-0000-abd2-2c3958e39793')
-		// 	}
-		// 	else {
-		// 		posthog.displaySurvey('019f3cf9-c8ba-0000-5d0d-31211fca0025')
-		// 	}
-		// }, 5000)
 	}
 
 	function clearSearchResults() {
@@ -93,7 +85,7 @@
 </script>
 
 <svelte:head>
-	<title>Semantic Search API Demo for GEO.ca</title>
+	<title>{m.website_header()}</title>
 	<link
 		rel="stylesheet"
 		href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css"

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -224,16 +224,19 @@
 		display: flex;
 		align-items: center;
 		gap: 2rem;
-		margin-left: 5rem;
-    	margin-right: 5rem;
+		margin-left: auto;
+		margin-right: auto;
+		width: max-content;
 	}
 	
 	.side-by-side select {
 		border: None;
 		padding-right: 2rem;
 		cursor: pointer;
-		background-color: none;
+		background-color: transparent;
 		text-transform: capitalize;
+		color: var(--pico-primary);
+    	font-weight: bold;
 	}
 
 	p.search-url {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,7 @@
 	import RecordCard from '$lib/components/RecordCard.svelte';
 	import Footer from '$lib/components/Footer.svelte';
 	import { m } from "../paraglide/messages.js";
-	import { setLocale } from "../paraglide/runtime.js";
+	import { setLocale, getLocale } from "../paraglide/runtime.js";
 
 	// Language configuration 
 	function switchLanguage(lang: 'en' | 'fr') {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,8 @@
 	import Footer from '$lib/components/Footer.svelte';
 
 	let query = $state('');
-	let leftMode = $state('');
-	let rigthMode = $state('');
+	let leftMode = $state('semantic_search');
+	let rightMode = $state('keyword_search');
 	
 	let keywordSearchURL = $derived(
 		`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
@@ -110,15 +110,15 @@
 
 	<section class="container">
 		<form role="comparison" onsubmit={setComparison}>
-		<select bind:value={rightMode} oninput={clearSearchResults}>
+		<select bind:value={leftMode} oninput={clearSearchResults}>
 			<option value="keyword_search">Keyword Search</option>
-			<option value="semantic_search_existing">Semantic Search</option>
+			<option value="semantic_search" selected>Semantic Search</option>
 			<option value="semantic_search_new">Semantic Search *New*</option>
 		</select>
 		<em> VS </em>
-		<select bind:value={leftMode} onsubmit={setComparison} oninput={clearSearchResults}>
-			<option value="keyword_search">Keyword Search</option>
-			<option value="semantic_search_existing">Semantic Search</option>
+		<select bind:value={rightMode} onsubmit={setComparison} oninput={clearSearchResults}>
+			<option value="keyword_search" selected>Keyword Search</option>
+			<option value="semantic_search">Semantic Search</option>
 			<option value="semantic_search_new">Semantic Search *New*</option>
 		</select>
 		<br>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,9 @@
 	import Footer from '$lib/components/Footer.svelte';
 
 	let query = $state('');
+	let leftMode = $state('');
+	let rigthMode = $state('');
+	let query = $state('');
 	let keywordSearchURL = $derived(
 		`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
 	);
@@ -107,13 +110,13 @@
 
 	<section class="container">
 		<form role="versus" onsubmit={setComparison} oninput={clearSearchResults}>
-		<select bind:value={right-mode}>
+		<select bind:value={rightMode}>
 			<option value="keyword_search">Keyword Search</option>
 			<option value="semantic_search_existing">Semantic Search</option>
 			<option value="semantic_search_new">Semantic Search *New*</option>
 		</select>
 		<em> VS </em>
-		<select bind:value={left-mode} oninput={clearSearchResults}>
+		<select bind:value={leftMode} onsubmit={setComparison} oninput={clearSearchResults}>
 			<option value="keyword_search">Keyword Search</option>
 			<option value="semantic_search_existing">Semantic Search</option>
 			<option value="semantic_search_new">Semantic Search *New*</option>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -56,6 +56,10 @@
 		
 		posthog.capture('search_performed', {
 			query,
+			locale: getLocale(),
+			leftMode,
+			rightMode,
+			timestamp: new Date().toISOString(),
 		})
 
 		promiseLeft = fetchSearchResults(urlLeft);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import Footer from '$lib/components/Footer.svelte';
 	import { m } from "$lib/paraglide/messages.js";
 	import { getLocale } from "$lib/paraglide/runtime.js";
+	import { get } from 'svelte/store';
 
 	let query = $state('');
 
@@ -51,6 +52,17 @@
 			return;
 		}
 		searchInitiated = true;
+		
+		posthog.capture('search_performed', {
+			query,
+		})
+
+		if getLocale() == 'en') {
+			posthog.displaySurvey('019f37a0-7c58-0000-abd2-2c3958e39793')
+		}
+		else {
+			posthog.displaySurvey('019f3cf9-c8ba-0000-5d0d-31211fca0025')
+		}
 
 		promiseLeft = fetchSearchResults(urlLeft);
 		promiseRight = fetchSearchResults(urlRight);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -178,21 +178,37 @@
 					{#await promiseLeft}
 						{@render loadingResults()}
 					{:then data}
-						{#if data.response && data.response.total_hits > 0}
-							<p class="center">1 – {data.response.returned_hits} of {data.response.total_hits} records</p>
-							<div class="search-results">
-								{#each data.response.items as item (item.features[0].properties.row_num)}
-									{@const record = item.features[0].properties}
-									<RecordCard {record} />
-								{/each}
-							</div>
-						{:else if data.response && data.response.total_hits === 0}
-							<p>No result</p>
+						{#if leftMode === 'keyword_search'}
+							{#if data.Count > 0}
+								<p class="center">1 – {data.Count} of {data.Items[0].total} records</p>
+								<div class="search-results">
+									{#each data.Items as record (record.row_num)}
+										<RecordCard {record} />
+									{/each}
+								</div>
+							{:else if data.Count === 0}
+								<p>No result</p>
+							{:else}
+								<p class="error">{data.errorMessage}</p>
+								<textarea rows="20" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
+							{/if}
 						{:else}
-							<p class="error">Parse error.  This demo likely needs to be updated to the latest API.</p>
-							<p>Returned results in JSON format:</p>
-							<p class="error">{data.message}</p>
-							<textarea rows="50" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
+							{#if data.response && data.response.total_hits > 0}
+								<p class="center">1 – {data.response.returned_hits} of {data.response.total_hits} records</p>
+								<div class="search-results">
+									{#each data.response.items as item (item.features[0].properties.row_num)}
+										{@const record = item.features[0].properties}
+										<RecordCard {record} />
+									{/each}
+								</div>
+							{:else if data.response && data.response.total_hits === 0}
+								<p>No result</p>
+							{:else}
+								<p class="error">Parse error.  This demo likely needs to be updated to the latest API.</p>
+								<p>Returned results in JSON format:</p>
+								<p class="error">{data.message}</p>
+								<textarea rows="50" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
+							{/if}
 						{/if}
 					{:catch error}
 						<p class="error">Error: {error}</p>
@@ -206,18 +222,37 @@
 					{#await promiseRight}
 						{@render loadingResults()}
 					{:then data}
-						{#if data.Count > 0}
-							<p class="center">1 – {data.Count} of {data.Items[0].total} records</p>
-							<div class="search-results">
-								{#each data.Items as record (record.row_num)}
-									<RecordCard {record} />
-								{/each}
-							</div>
-						{:else if data.Count === 0}
-							<p>No result</p>
+						{#if rightMode === 'keyword_search'}
+							{#if data.Count > 0}
+								<p class="center">1 – {data.Count} of {data.Items[0].total} records</p>
+								<div class="search-results">
+									{#each data.Items as record (record.row_num)}
+										<RecordCard {record} />
+									{/each}
+								</div>
+							{:else if data.Count === 0}
+								<p>No result</p>
+							{:else}
+								<p class="error">{data.errorMessage}</p>
+								<textarea rows="20" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
+							{/if}
 						{:else}
-							<p class="error">{data.errorMessage}</p>
-							<textarea rows="20" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
+							{#if data.response && data.response.total_hits > 0}
+								<p class="center">1 – {data.response.returned_hits} of {data.response.total_hits} records</p>
+								<div class="search-results">
+									{#each data.response.items as item (item.features[0].properties.row_num)}
+										{@const record = item.features[0].properties}
+										<RecordCard {record} />
+									{/each}
+								</div>
+							{:else if data.response && data.response.total_hits === 0}
+								<p>No result</p>
+							{:else}
+								<p class="error">Parse error.  This demo likely needs to be updated to the latest API.</p>
+								<p>Returned results in JSON format:</p>
+								<p class="error">{data.message}</p>
+								<textarea rows="50" spellcheck="false">{JSON.stringify(data, null, 4)}</textarea>
+							{/if}
 						{/if}
 					{:catch error}
 						<p class="error">Error: {error}</p>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -54,6 +54,10 @@
 		}
 		searchInitiated = true;
 		
+		posthog.register({
+			search_query: query
+		})
+		
 		posthog.capture('search_performed', {
 			query,
 			locale: getLocale(),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,8 +5,16 @@
 	import Footer from '$lib/components/Footer.svelte';
 
 	let query = $state('');
-	let leftMode = $state('semantic_search');
-	let rightMode = $state('keyword_search');
+
+	
+	const searchOptions = [
+		{ value: 'keyword_search', label: 'Keyword Search' },
+		{ value: 'semantic_search', label: 'Semantic Search' },
+		{ value: 'semantic_search_new', label: 'Semantic Search *New*' }
+	];
+
+	let rightMode = $state(searchOptions[0]);
+	let leftMode = $state(searchOptions[1]);
 	
 	let keywordSearchURL = $derived(
 		`https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`
@@ -48,7 +56,7 @@
 		searchInitiated = false;
 	}
 
-	function setComparison() {
+	function refreshSearchResults() {
 		console.log("Set comparison")
 	}
 </script>
@@ -109,17 +117,19 @@
 	</section>
 
 	<section class="container">
-		<form role="comparison" onsubmit={setComparison}>
-		<select bind:value={leftMode} oninput={clearSearchResults}>
-			<option value="keyword_search">Keyword Search</option>
-			<option value="semantic_search" selected>Semantic Search</option>
-			<option value="semantic_search_new">Semantic Search *New*</option>
+		<form role="comparison">
+		<select bind:value={leftMode} onchange={refreshSearchResults}>
+			{#each searchOptions as option}
+				<option value={option.value}>
+					{option.label}
+				</option>
+			{/each}
 		</select>
 		<em> VS </em>
-		<select bind:value={rightMode} onsubmit={setComparison} oninput={clearSearchResults}>
-			<option value="keyword_search" selected>Keyword Search</option>
-			<option value="semantic_search">Semantic Search</option>
-			<option value="semantic_search_new">Semantic Search *New*</option>
+		<select bind:value={rightMode} onchange={refreshSearchResults}>
+			{#each searchOptions as option}
+				<option value={option.value}> {option.label} </option>
+			{/each}
 		</select>
 		<br>
 		<input type="submit" value="Search" />
@@ -138,7 +148,7 @@
 		{#if searchInitiated}
 			<div class="grid">
 				<div>
-					<h2>Semantic search results</h2>
+					<h2>{leftMode} results</h2>
 					<!-- <p>Sorted by relevancy</p> -->
 					{@render showSearchURL(semanticSearchURL)}
 					{#await semanticPromise}
@@ -166,7 +176,7 @@
 				</div>
 
 				<div>
-					<h2>Keyword search results</h2>
+					<h2>{rightMode} results</h2>
 					<!-- <p>Sorted by popularity (relevancy not available)</p> -->
 					{@render showSearchURL(keywordSearchURL)}
 					{#await keywordPromise}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -15,10 +15,10 @@
 
 	// Define a mapping of search modes to their corresponding API endpoints
 	type SearchEngine = 'keyword_search' | 'semantic_search' | 'semantic_search_new';
-	const engineApiMap: Record<SearchEngine, (query: string) => string> = {
-		keyword_search: (q) => `https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(query)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`,
-		semantic_search: (q) => `https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`,
-		semantic_search_new: (q) => `https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(query)}`
+	const searchApiMap: Record<SearchEngine, (query: string) => string> = {
+		keyword_search: (q) => `https://geocore.api.geo.ca/geo?keyword=${encodeURIComponent(q)}&keyword_only=true&lang=en&min=1&max=10&sort=popularity-desc`,
+		semantic_search: (q) => `https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(q)}`,
+		semantic_search_new: (q) => `https://search-recherche.geocore.api.geo.ca/search-opensearch?method=SemanticSearch&q=${encodeURIComponent(q)}`
 	};
 
 	let rightMode = $state(searchOptions[0].value);
@@ -56,6 +56,10 @@
 	// 	const data = await res.json();
 	// 	return data;
 	// }
+	
+	// Derive the search URLs based on the selected modes and query
+	const urlLeft = $derived(searchApiMap[leftMode](query));
+	const urlRight = $derived(searchApiMap[rightMode](query));
 
 	async function handleSearch(event: Event) {
 		event.preventDefault();
@@ -64,9 +68,6 @@
 			return;
 		}
 		searchInitiated = true;
-
-		const urlLeft = $derived(engineApiMap[leftMode](query));
-		const urlRight = $derived(engineApiMap[rightMode](query));
 
 		promiseLeft = fetchSearchResults(urlLeft);
 		promiseRight = fetchSearchResults(urlRight);
@@ -171,7 +172,7 @@
 				<div>
 					<h2>{searchOptionLabels[leftMode]} results</h2>
 					<!-- <p>Sorted by relevancy</p> -->
-					{@render showSearchURL($derived(engineApiMap[leftMode](query)))}
+					{@render showSearchURL(urlLeft)}
 					{#await promiseLeft}
 						{@render loadingResults()}
 					{:then data}
@@ -199,7 +200,7 @@
 				<div>
 					<h2>{searchOptionLabels[rightMode]} results</h2>
 					<!-- <p>Sorted by popularity (relevancy not available)</p> -->
-					{@render showSearchURL($derived(engineApiMap[rightMode](query)))}
+					{@render showSearchURL(urlRight)}
 					{#await promiseRight}
 						{@render loadingResults()}
 					{:then data}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,9 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
+import { paraglide } from '@inlang/paraglide-vite';
 
 export default defineConfig({
-	plugins: [sveltekit()],
+	plugins: [sveltekit(), paraglide()],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,13 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
-import { paraglide } from '@inlang/paraglide-vite';
+import { paraglideVitePlugin } from '@inlang/paraglide-js';
 
 export default defineConfig({
-	plugins: [sveltekit(), paraglide()],
+	plugins: [sveltekit(), , 
+              paraglideVitePlugin({
+                  project: "./project.inlang",
+                  outdir: "./src/paraglide"
+              })],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,9 @@
+import { paraglideVitePlugin } from '@inlang/paraglide-js'
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
-import { paraglideVitePlugin } from '@inlang/paraglide-js';
 
 export default defineConfig({
-	plugins: [sveltekit(), , 
-              paraglideVitePlugin({
-                  project: "./project.inlang",
-                  outdir: "./src/paraglide"
-              })],
+	plugins: [paraglideVitePlugin({ project: './project.inlang', outdir: './src/paraglide' }),sveltekit(),],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-	plugins: [paraglideVitePlugin({ project: './project.inlang', outdir: './src/paraglide' }),sveltekit(),],
+	plugins: [paraglideVitePlugin({ project: './project.inlang', outdir: './src/lib/paraglide' }),sveltekit(),],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}


### PR DESCRIPTION
Extended search comparison to allow for comparison of any search system with any search system. Added bilingual support for all displayed content.

Details:
- Added drop-downs before search bar to allow for user selection of search system/mode for comparison. Values include the original Keyword Search and Semantic Search, alongside Semantic Search \*New\* for testing new semantic search model against old.
- On drop-down value change, previous search results are cleared (since new API call will need to be used) but query remains the same (for easier result comparison across all search modes)
- Language toggle is added to the top right of the website. Clicking it, reloads the page with all text content on the webpage translated to the language specified on the toggle button (required addition of paraglide-js dependency). EN and FR content is all stored under `./src/i18n/`
- Posthog event trigger added to search initiation: once the Search button is clicked, Posthog records the search query, locale, and models involved in comparison as property definitions and creates a `search_performed` event. On PostHog UI, EN and FR versions of the survey are triggered on this `search_performed` event, wait for 10 seconds, before appearing to the user. Locale recorded in event is used to determine with version of the survey to display. Once dismissed or submitted, survey will only show up again after the Search button is clicked.

**Use cases:**
- A/B testing for search systems with human feedback via Posthog surveys
- Bilingual support for improving accessibility, allowing cross-lingual evaluation of search systems